### PR TITLE
Make config path use XDG_CONFIG_HOME else ~/.config instead of just $HOME

### DIFF
--- a/OmniMIDI/src/Utils.cpp
+++ b/OmniMIDI/src/Utils.cpp
@@ -308,7 +308,15 @@ bool OMShared::Funcs::GetFolderPath(const FIDs FolderID, char* path, size_t szPa
 		envPath = "/usr/lib/aarch64-linux-gnu";
 		break;
 	case UserFolder:
-		envPath = std::getenv("HOME");
+		if (std::getenv("XDG_CONFIG_HOME") != nullptr) {
+			envPath = std::getenv("XDG_CONFIG_HOME");
+		}
+		else {
+			// Default to ~/.config
+			static std::string configPath = std::format("{0}/.config", std::getenv("HOME"));
+			envPath = configPath.c_str();
+		}
+
 		break;
 	case CurrentDirectory:
 		return getcwd(path, szPath) != 0;

--- a/OmniMIDI/src/Utils.hpp
+++ b/OmniMIDI/src/Utils.hpp
@@ -16,6 +16,7 @@
 #include <cassert>
 #include "Common.hpp"
 #include "ErrSys.hpp"
+#include <format>
 
 #ifdef _WIN32
 #include <windows.h>

--- a/OmniMIDI/xmake.lua
+++ b/OmniMIDI/xmake.lua
@@ -6,7 +6,7 @@ set_allowedmodes("debug", "release")
 set_allowedarchs("x86", "x64", "x86_64", "arm64")
 	
 add_rules("mode.release", "mode.debug")
-set_languages("clatest", "cxx2a")
+set_languages("clatest", "cxx2a", "c++20")
 set_runtimes("stdc++_static")
 
 target("OmniMIDI")


### PR DESCRIPTION
I don't know why it was by default using $HOME instead of using the proper XDG_CONFIG_HOME path, but here is the fix for that