### PR TITLE
XSynth & other fixes

### DIFF
--- a/OmniMIDI/.gitignore
+++ b/OmniMIDI/.gitignore
@@ -5,4 +5,5 @@ build/
 # MacOS Cache
 .DS_Store
 
-
+# Language Server
+.clangd

--- a/OmniMIDI/src/BASSSynth.cpp
+++ b/OmniMIDI/src/BASSSynth.cpp
@@ -451,12 +451,11 @@ bool OmniMIDI::BASSSynth::StartSynthModule() {
 
 	// BASS stream flags
 	bool bInfoGood = false;
-	bool noFreqChange = false;
-	double devFreq = 0.0;
-	unsigned int minBuf = 0;
 	BASS_INFO defInfo = BASS_INFO();
 
 #if defined(_WIN32)
+	bool noFreqChange = false;
+	double devFreq = 0.0;
 	BASS_ASIO_INFO asioInfo = BASS_ASIO_INFO();
 	BASS_ASIO_DEVICEINFO devInfo = BASS_ASIO_DEVICEINFO();
 	BASS_ASIO_CHANNELINFO chInfo = BASS_ASIO_CHANNELINFO();
@@ -517,7 +516,6 @@ bool OmniMIDI::BASSSynth::StartSynthModule() {
 		BASS_SetConfig(BASS_CONFIG_DEV_DEFAULT, 1);
 		if (BASS_Init(-1, Settings->SampleRate, BASS_DEVICE_STEREO, 0, nullptr)) {
 			if ((bInfoGood = BASS_GetInfo(&defInfo))) {
-				minBuf = defInfo.minbuf;
 				Message("minbuf %d", defInfo.minbuf);
 			}
 

--- a/OmniMIDI/src/BASSSynth.hpp
+++ b/OmniMIDI/src/BASSSynth.hpp
@@ -6,10 +6,10 @@
 
 */
 
+#ifdef _NONFREE
+
 #ifndef _BASSSYNTH_H
 #define _BASSSYNTH_H
-
-#ifdef _NONFREE
 
 // Always first
 #include "Common.hpp"

--- a/OmniMIDI/src/ErrSys.hpp
+++ b/OmniMIDI/src/ErrSys.hpp
@@ -31,7 +31,7 @@
 #ifdef _WIN32
 #define MsgBox						MessageBoxA
 #else
-#define MsgBox(...)					0
+#define MsgBox(...)
 #define MB_ICONWARNING				0
 #define MB_ICONERROR				0
 #define MB_SYSTEMMODAL				0

--- a/OmniMIDI/src/SynthHost.cpp
+++ b/OmniMIDI/src/SynthHost.cpp
@@ -277,7 +277,6 @@ OmniMIDI::SynthResult OmniMIDI::SynthHost::PlayLongEvent(char* ev, unsigned int 
 		case SystemMessageStart:
 		{
 			bool notSpecial = false;
-			unsigned char pos = 0;
 			unsigned char vendor = ev[readHead + 1] & 0xFF;
 
 			readHead += 2;

--- a/OmniMIDI/src/SynthMain.hpp
+++ b/OmniMIDI/src/SynthMain.hpp
@@ -10,6 +10,7 @@
 #ifndef _SYNTHMAIN_H
 #define _SYNTHMAIN_H
 
+#include <cstdint>
 #pragma once
 
 // Uncomment this if you want stats to be shown once the synth is closed
@@ -372,7 +373,7 @@ namespace OmniMIDI {
 #endif
 
 		virtual void LogFunc() {
-			const char Templ[] = "R%06.2f%% >> P%d (Ev%08zu/%08zu)";
+			const char Templ[] = "R%06.2f%% >> P%llu (Ev%08zu/%08zu)";
 			char* Buf = new char[96];
 
 			while (!IsSynthInitialized())
@@ -385,7 +386,7 @@ namespace OmniMIDI {
 				Utils.MicroSleep(-1);
 			}
 
-			sprintf(Buf, Templ, 0.0f, 0, (size_t)0, (size_t)0);
+			sprintf(Buf, Templ, 0.0f, (unsigned long long)0, (size_t)0, (size_t)0);
 			SetTerminalTitle(Buf);
 
 			delete[] Buf;

--- a/OmniMIDI/src/Utils.cpp
+++ b/OmniMIDI/src/Utils.cpp
@@ -51,7 +51,6 @@ bool OMShared::Lib::IteratePath(char* outPath, OMShared::FIDs fid) {
 
 bool OMShared::Lib::GetLibPath(char* outPath) {
 	bool skip = false;
-	bool gotLib = false;
 
 	if (outPath == nullptr)
 		return false;
@@ -64,7 +63,6 @@ bool OMShared::Lib::GetLibPath(char* outPath) {
 		auto _ = loadLib(outPath);
 		if (_ != nullptr) {
 			freeLib(_);
-			gotLib = true;
 		}
 	}
 

--- a/OmniMIDI/src/XSynthM.hpp
+++ b/OmniMIDI/src/XSynthM.hpp
@@ -32,9 +32,10 @@ namespace OmniMIDI {
 	public:
 		// Global settings
 		bool FadeOutKilling = false;
-		double RenderWindow = 5.0;
-		uint64_t LayerCount = 2;
-		int32_t ThreadsCount = 1;
+		double RenderWindow = 10.0;
+		uint64_t LayerCount = 4;
+		int32_t ThreadsCount = 0;
+		uint8_t Interpolation = XSYNTH_INTERPOLATION_NEAREST;
 
 		XSynthSettings(ErrorSystem::Logger* PErr) : SettingsModule(PErr) {}
 
@@ -44,6 +45,7 @@ namespace OmniMIDI {
 					ConfGetVal(RenderWindow),
 					ConfGetVal(ThreadsCount),
 					ConfGetVal(LayerCount),
+					ConfGetVal(Interpolation),
 			};
 
 			if (AppendToConfig(DefConfig))
@@ -60,6 +62,7 @@ namespace OmniMIDI {
 				SynthSetVal(double, RenderWindow);
 				SynthSetVal(int32_t, ThreadsCount);
 				SynthSetVal(uint64_t, LayerCount);
+				SynthSetVal(uint8_t, Interpolation);
 			
 				if (!RANGE(ThreadsCount, -1, std::thread::hardware_concurrency()))
 					ThreadsCount = -1;
@@ -86,7 +89,8 @@ namespace OmniMIDI {
 		XSynth_RealtimeStats realtimeStats;
 		std::jthread _XSyThread;
 
-		LibImport xLibImp[12] = {
+		LibImport xLibImp[14] = {
+			ImpFunc(XSynth_GetVersion),
 			ImpFunc(XSynth_GenDefault_RealtimeConfig),
 			ImpFunc(XSynth_GenDefault_SoundfontOptions),
 			ImpFunc(XSynth_Realtime_Drop),
@@ -98,7 +102,8 @@ namespace OmniMIDI {
 			ImpFunc(XSynth_Realtime_SendConfigEventAll),
 			ImpFunc(XSynth_Realtime_SetSoundfonts),
 			ImpFunc(XSynth_Realtime_ClearSoundfonts),
-			ImpFunc(XSynth_Soundfont_LoadNew)
+			ImpFunc(XSynth_Soundfont_LoadNew),
+			ImpFunc(XSynth_Soundfont_Remove)
 		};
 		size_t xLibImpLen = sizeof(xLibImp) / sizeof(xLibImp[0]);
 
@@ -107,6 +112,7 @@ namespace OmniMIDI {
 		bool Running = false;
 
 		void XSynthThread();
+		void UnloadSoundfonts();
 
 	public:
 		XSynth(ErrorSystem::Logger* PErr) : SynthModule(PErr) {}

--- a/OmniMIDI/xmake.lua
+++ b/OmniMIDI/xmake.lua
@@ -1,4 +1,4 @@
-set_xmakever("2.9.8")
+set_xmakever("2.9.5")
 set_project("OmniMIDIv2")
 
 set_allowedplats("windows", "linux")
@@ -16,6 +16,8 @@ option("nonfree")
 
 -- Self-hosted MIDI out for Linux
 target("OmniMIDI")
+	add_options("nonfree")
+
 	if is_plat("windows") then 	
 		-- Dummy
 		set_enabled(false)	
@@ -39,7 +41,6 @@ target("OmniMIDI")
 
 		add_includedirs("inc")
 		add_files("src/*.cpp")
-		add_files("src/weak_libjack.c")
 
 		set_toolchains("gcc")
 
@@ -61,7 +62,6 @@ target_end()
 target("libOmniMIDI")
 	set_kind("shared")
 	set_basename("OmniMIDI")
-	set_options("nonfree")
 
 	if is_mode("debug") then
 		add_defines("DEBUG")
@@ -97,9 +97,9 @@ target("libOmniMIDI")
 
 		remove_files("UnixEntry.cpp")
 	else
-		set_toolchains("gcc")
+		set_toolchains("clang")
 
-		add_cxflags("-fvisibility=hidden", "-fvisibility-inlines-hidden")
+		add_cxflags("-fvisibility=hidden", "-fvisibility-inlines-hidden", "-Wall")
 		add_syslinks("asound")
 
 		remove_files("bassasio.cpp")

--- a/OmniMIDI/xmake.lua
+++ b/OmniMIDI/xmake.lua
@@ -16,8 +16,6 @@ option("nonfree")
 
 -- Self-hosted MIDI out for Linux
 target("OmniMIDI")
-	add_options("nonfree")
-
 	if is_plat("windows") then 	
 		-- Dummy
 		set_enabled(false)	
@@ -62,6 +60,7 @@ target_end()
 target("libOmniMIDI")
 	set_kind("shared")
 	set_basename("OmniMIDI")
+	set_options("nonfree")
 
 	if is_mode("debug") then
 		add_defines("DEBUG")


### PR DESCRIPTION
### General
- ~~Fixed a build error on Linux~~
- Changed toolchain to Clang (I can revert that if it is a problem) and fixed compile warnings
- ~~Added XMake option for enabling/disabling nonfree (`xmake f --nonfree=[y|n]`, default is enabled)~~

### XSynth
- Properly unload soundfonts so they do not stay in memory when unloading the synth
- Add option for interpolation type
- Check API<->LIB compatibility when loading